### PR TITLE
ci: set gh_token env var

### DIFF
--- a/.github/workflows/bump-crossplane.yaml
+++ b/.github/workflows/bump-crossplane.yaml
@@ -14,6 +14,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Bump crossplane formula versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: bump_crossplane
         run: |
           bin/bump-formula-crossplane.sh -v ${{ github.event.inputs.new_version }}


### PR DESCRIPTION
It is needed by the bump-crossplane script